### PR TITLE
Add duplicate vote prevention for gardening tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ A blockchain-based gardening companion app that allows users to create and share
 - Share gardening tips and advice
 - Community rewards for valuable contributions
 - Plant care achievements and badges
+- Single vote per user for each tip
+- Track tip voters to prevent duplicate voting
 
 ## Smart Contract
 The smart contract handles:
 - Plant care schedule management
-- Community tip submissions and voting
+- Community tip submissions and voting with duplicate prevention
 - Reward token distribution
 - Achievement tracking

--- a/contracts/plant_care.clar
+++ b/contracts/plant_care.clar
@@ -27,6 +27,7 @@
     author: principal,
     content: (string-ascii 500),
     votes: uint,
+    voters: (list 50 principal),
     created-at: uint
   }
 )
@@ -76,6 +77,7 @@
                 author: tx-sender,
                 content: content,
                 votes: u0,
+                voters: (list),
                 created-at: block-height
             }
         ))
@@ -89,10 +91,15 @@
         (
             (tip (unwrap! (map-get? gardening-tips {tip-id: tip-id}) err-invalid-tip))
             (current-votes (get votes tip))
+            (voters (get voters tip))
         )
+        (asserts! (is-none (index-of voters tx-sender)) err-already-voted)
         (map-set gardening-tips
             {tip-id: tip-id}
-            (merge tip {votes: (+ current-votes u1)})
+            (merge tip {
+              votes: (+ current-votes u1),
+              voters: (unwrap! (as-max-len? (append voters tx-sender) u50) err-invalid-tip)
+            })
         )
         ;; Reward tip author
         (try! (ft-mint? sprout-token u1 (get author tip)))

--- a/tests/plant_care_test.ts
+++ b/tests/plant_care_test.ts
@@ -54,6 +54,15 @@ Clarinet.test({
         
         voteBlock.receipts[0].result.expectOk().expectBool(true);
         
+        // Try voting again with same user - should fail
+        let duplicateVote = chain.mineBlock([
+            Tx.contractCall('plant-care', 'vote-for-tip', [
+                types.uint(1)
+            ], wallet_2.address)
+        ]);
+        
+        duplicateVote.receipts[0].result.expectErr().expectUint(103);
+        
         let getTip = chain.mineBlock([
             Tx.contractCall('plant-care', 'get-tip', [
                 types.uint(1)


### PR DESCRIPTION
This PR enhances the gardening tips voting system by preventing duplicate votes from the same user. Key changes include:

1. Added a voters list to the gardening-tips map to track who has voted for each tip
2. Added validation to check if a user has already voted before allowing a new vote
3. Added new error constant err-already-voted for duplicate voting attempts
4. Updated tests to verify duplicate vote prevention
5. Updated README to reflect the new voting features

These changes improve the fairness and integrity of the community voting system while maintaining backward compatibility with existing functionality.

Changes are needed because the original implementation allowed users to vote multiple times for the same tip, which could lead to vote manipulation and unfair token distribution.

The enhancement adds minimal storage overhead while providing important voting integrity features.